### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.10.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "express-rate-limit": "^7.5.1"
+    "express-rate-limit": "^7.5.1",
+    "sanitize-filename": "^1.6.3"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ChrisK106/OW-Scraper/security/code-scanning/6](https://github.com/ChrisK106/OW-Scraper/security/code-scanning/6)

To fix the issue, we need to sanitize the user-provided inputs (`req.query.from` and `req.query.to`) before using them to construct the file path. Since these inputs are expected to be numeric values, we can validate them to ensure they are integers within a reasonable range. Additionally, we can use a library like `sanitize-filename` to ensure the generated `downloadFilename` does not contain any invalid or dangerous characters.

Steps to fix:
1. Validate `req.query.from` and `req.query.to` to ensure they are integers. If they are invalid, default to safe values (e.g., `1` and `20`).
2. Use the `sanitize-filename` library to sanitize the `downloadFilename` before constructing the `filePath`.
3. Ensure the `filePath` is resolved to a safe directory (`./public`) using `path.resolve` and verify it starts with the intended root directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
